### PR TITLE
fix: load update-incident options lazily and pin Node 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUN
 
-FROM node:lts-alpine as builderenv
+FROM node:24.18.0-alpine as builderenv
 
 WORKDIR /app
 
@@ -21,7 +21,7 @@ RUN yarn install --prod --frozen-lockfile
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:lts-alpine
+FROM node:24.18.0-alpine
 
 # NODE_ENV is used to configure some runtime options, like JSON logger
 ENV NODE_ENV production

--- a/src/adapters/bolt.ts
+++ b/src/adapters/bolt.ts
@@ -1,11 +1,11 @@
 import {
   App,
   BlockAction,
+  ExternalSelectAction,
   PlainTextInput,
   PlainTextOption,
   SectionBlock,
   StaticSelect,
-  StaticSelectAction,
   UsersSelect,
   View
 } from '@slack/bolt'
@@ -138,40 +138,10 @@ export async function createBoltComponent(
       // Get all incidents
       const queryResult = await pg.query<IncidentRow>(GET_LAST_UPDATE_OF_ALL_INCIDENTS_FEW_COLUMNS)
 
-      // Separate between open, closed and invalid
-      const open: IncidentRow[] = []
-      const closed: IncidentRow[] = []
-      const invalid: IncidentRow[] = []
-      queryResult.rows.forEach((incident: IncidentRow) => {
-        if (incident.status === 'open') open.push(incident)
-        else if (incident.status === 'closed') closed.push(incident)
-        else invalid.push(incident)
-      })
-
-      // Sort them individually
-      open.sort(compareBySeverity)
-      closed.sort(compareByDate)
-      invalid.sort(compareByDate)
-
-      // Build options for the incidents menu
-      const loadedIncidentsOptions: PlainTextOption[] = []
-      open
-        .concat(closed)
-        .concat(invalid)
-        .forEach((incident: IncidentRow) => {
-          const text = `${getEmoji(incident)} DCL-${incident.id} ${incident.title}`
-
-          loadedIncidentsOptions.push({
-            text: {
-              type: 'plain_text',
-              text: text.substring(0, 75),
-              emoji: true
-            },
-            value: incident.id.toString()
-          })
-        })
-
       if (queryResult.rowCount > 0) {
+        // The incidents are loaded lazily through an external_select so we never hit
+        // Slack's 100-option limit on a static_select (the incident list keeps growing).
+        // Options are provided by the `loaded_incidents` app.options handler below.
         await client.views.open({
           trigger_id: body.trigger_id,
           view: {
@@ -188,8 +158,13 @@ export async function createBoltComponent(
                 elements: [
                   {
                     action_id: 'loaded_incidents',
-                    type: 'static_select',
-                    options: loadedIncidentsOptions
+                    type: 'external_select',
+                    placeholder: {
+                      type: 'plain_text',
+                      text: 'Select an incident'
+                    },
+                    // Load options as soon as the menu is opened (no typing required).
+                    min_query_length: 0
                   }
                 ]
               }
@@ -212,6 +187,26 @@ export async function createBoltComponent(
     }
   })
 
+  // Provide the options for the `loaded_incidents` external_select. Slack calls this
+  // as the user opens/types in the menu, so we filter server-side and cap the response
+  // at Slack's 100-option limit instead of trying to push every incident into the view.
+  app.options('loaded_incidents', async ({ options, ack, logger }) => {
+    try {
+      const queryResult = await pg.query<IncidentRow>(GET_LAST_UPDATE_OF_ALL_INCIDENTS_FEW_COLUMNS)
+      const incidentsOptions = buildLoadedIncidentsOptions(queryResult.rows)
+
+      const query = (options.value ?? '').toLowerCase()
+      const matches = query
+        ? incidentsOptions.filter((option) => option.text.text.toLowerCase().includes(query))
+        : incidentsOptions
+
+      await ack({ options: matches.slice(0, MAX_SELECT_OPTIONS) })
+    } catch (error) {
+      logger.error(JSON.stringify(error))
+      await ack({ options: [] })
+    }
+  })
+
   app.action('loaded_incidents', async ({ ack, body, logger, client }) => {
     await ack()
 
@@ -219,8 +214,9 @@ export async function createBoltComponent(
       // Get data from body
       const blockActionBody = body as BlockAction
       const previousView = blockActionBody.view
-      const action = blockActionBody.actions[0] as StaticSelectAction
-      const selectedIncidentId = action.selected_option.value
+      const action = blockActionBody.actions[0] as ExternalSelectAction
+      const selectedIncidentId = action.selected_option?.value
+      if (!selectedIncidentId) return
 
       // Get last update for selected incident
       const queryResult = await pg.query<IncidentRow>(GET_LAST_UPDATE_OF_SELECTED_INCIDENT(selectedIncidentId))
@@ -397,6 +393,42 @@ export async function createBoltComponent(
   }
 
   return bolt
+}
+
+// Slack rejects a select menu with more than 100 options.
+const MAX_SELECT_OPTIONS = 100
+
+// Turns incident rows into select options, ordered the way we want them surfaced:
+// open incidents first (by severity), then closed and invalid (by date).
+function buildLoadedIncidentsOptions(incidents: IncidentRow[]): PlainTextOption[] {
+  const open: IncidentRow[] = []
+  const closed: IncidentRow[] = []
+  const invalid: IncidentRow[] = []
+  incidents.forEach((incident: IncidentRow) => {
+    if (incident.status === 'open') open.push(incident)
+    else if (incident.status === 'closed') closed.push(incident)
+    else invalid.push(incident)
+  })
+
+  open.sort(compareBySeverity)
+  closed.sort(compareByDate)
+  invalid.sort(compareByDate)
+
+  return open
+    .concat(closed)
+    .concat(invalid)
+    .map((incident: IncidentRow) => {
+      const text = `${getEmoji(incident)} DCL-${incident.id} ${incident.title}`
+
+      return {
+        text: {
+          type: 'plain_text',
+          text: text.substring(0, 75),
+          emoji: true
+        },
+        value: incident.id.toString()
+      }
+    })
 }
 
 const severitiesOptions = {

--- a/src/adapters/bolt.ts
+++ b/src/adapters/bolt.ts
@@ -14,6 +14,7 @@ import { compareByDate, compareBySeverity, getEmoji } from '../logic/incidents'
 import { getusername, updateChannelTopic } from '../logic/slack'
 import {
   CREATE_INCIDENT,
+  EXISTS_ANY_INCIDENT,
   GET_LAST_UPDATE_OF_ALL_INCIDENTS_FEW_COLUMNS,
   GET_LAST_UPDATE_OF_SELECTED_INCIDENT,
   UPDATE_INCIDENT
@@ -135,8 +136,9 @@ export async function createBoltComponent(
     await ack()
 
     try {
-      // Get all incidents
-      const queryResult = await pg.query<IncidentRow>(GET_LAST_UPDATE_OF_ALL_INCIDENTS_FEW_COLUMNS)
+      // Only check whether there is at least one incident; the actual options are
+      // fetched lazily by the `loaded_incidents` app.options handler below.
+      const queryResult = await pg.query(EXISTS_ANY_INCIDENT)
 
       if (queryResult.rowCount > 0) {
         // The incidents are loaded lazily through an external_select so we never hit
@@ -400,7 +402,7 @@ const MAX_SELECT_OPTIONS = 100
 
 // Turns incident rows into select options, ordered the way we want them surfaced:
 // open incidents first (by severity), then closed and invalid (by date).
-function buildLoadedIncidentsOptions(incidents: IncidentRow[]): PlainTextOption[] {
+export function buildLoadedIncidentsOptions(incidents: IncidentRow[]): PlainTextOption[] {
   const open: IncidentRow[] = []
   const closed: IncidentRow[] = []
   const invalid: IncidentRow[] = []

--- a/src/logic/queries.ts
+++ b/src/logic/queries.ts
@@ -47,7 +47,9 @@ export const GET_LAST_UPDATE_OF_ALL_INCIDENTS_FEW_COLUMNS = SQL`SELECT
   ) t JOIN incidents m ON m.id = t.id AND t.last = m.update_number;
 `
 
-export const GET_LAST_UPDATE_OF_ALL_INCIDENTS = SQL`SELECT 
+export const EXISTS_ANY_INCIDENT = SQL`SELECT 1 FROM incidents LIMIT 1;`
+
+export const GET_LAST_UPDATE_OF_ALL_INCIDENTS = SQL`SELECT
     m.id,
     m.update_number,
     m.modified_at,

--- a/test/unit/bolt.spec.ts
+++ b/test/unit/bolt.spec.ts
@@ -1,0 +1,126 @@
+import { buildLoadedIncidentsOptions } from "../../src/adapters/bolt"
+import { IncidentRow } from "../../src/types"
+import { buildTemplateIncident } from "../components"
+
+describe("bolt-unit", () => {
+  describe("buildLoadedIncidentsOptions", () => {
+    describe("when there are no incidents", () => {
+      let incidents: IncidentRow[]
+
+      beforeEach(() => {
+        incidents = []
+      })
+
+      it("should return an empty list of options", () => {
+        expect(buildLoadedIncidentsOptions(incidents)).toEqual([])
+      })
+    })
+
+    describe("when there are open, closed and invalid incidents in an arbitrary order", () => {
+      let incidents: IncidentRow[]
+
+      beforeEach(() => {
+        const openSev2 = {
+          ...buildTemplateIncident(),
+          id: 1,
+          status: "open",
+          severity: "sev-2",
+          reported_at: new Date("2022-07-19")
+        } as IncidentRow
+        const openSev1Later = {
+          ...buildTemplateIncident(),
+          id: 2,
+          status: "open",
+          severity: "sev-1",
+          reported_at: new Date("2022-07-10")
+        } as IncidentRow
+        const openSev1Earlier = {
+          ...buildTemplateIncident(),
+          id: 3,
+          status: "open",
+          severity: "sev-1",
+          reported_at: new Date("2022-07-05")
+        } as IncidentRow
+        const closedOlder = {
+          ...buildTemplateIncident(),
+          id: 4,
+          status: "closed",
+          reported_at: new Date("2022-06-01")
+        } as IncidentRow
+        const closedNewer = {
+          ...buildTemplateIncident(),
+          id: 5,
+          status: "closed",
+          reported_at: new Date("2022-08-01")
+        } as IncidentRow
+        const invalidOlder = {
+          ...buildTemplateIncident(),
+          id: 6,
+          status: "invalid",
+          reported_at: new Date("2022-05-01")
+        } as IncidentRow
+        const invalidNewer = {
+          ...buildTemplateIncident(),
+          id: 7,
+          status: "invalid",
+          reported_at: new Date("2022-09-01")
+        } as IncidentRow
+
+        incidents = [invalidOlder, openSev2, closedOlder, openSev1Later, invalidNewer, openSev1Earlier, closedNewer]
+      })
+
+      it("should list open incidents first (ascending severity, then date), followed by closed then invalid ordered by descending date", () => {
+        const values = buildLoadedIncidentsOptions(incidents).map((option) => option.value)
+        expect(values).toEqual(["3", "2", "1", "5", "4", "7", "6"])
+      })
+    })
+
+    describe("when an incident produces an option text longer than 75 characters", () => {
+      let incidents: IncidentRow[]
+
+      beforeEach(() => {
+        incidents = [
+          {
+            ...buildTemplateIncident(),
+            id: 8,
+            status: "open",
+            reported_at: new Date("2022-07-10"),
+            title: "a".repeat(100)
+          } as IncidentRow
+        ]
+      })
+
+      it("should truncate the option text to 75 characters", () => {
+        expect(buildLoadedIncidentsOptions(incidents)[0].text.text).toHaveLength(75)
+      })
+    })
+
+    describe("when building the option for a single open incident", () => {
+      let incidents: IncidentRow[]
+
+      beforeEach(() => {
+        incidents = [
+          {
+            ...buildTemplateIncident(),
+            id: 42,
+            status: "open",
+            reported_at: new Date("2022-07-10"),
+            title: "Database is down"
+          } as IncidentRow
+        ]
+      })
+
+      it("should use the incident id as the option value", () => {
+        expect(buildLoadedIncidentsOptions(incidents)[0].value).toEqual("42")
+      })
+
+      it("should render the status emoji, DCL id and title as a plain_text element", () => {
+        expect(buildLoadedIncidentsOptions(incidents)[0].text).toEqual({
+          type: "plain_text",
+          text: "🚨 DCL-42 Database is down",
+          emoji: true
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the recurring Slack error on `/update-incident`:

```
[ERROR] failed to match all allowed schemas [json-pointer:/view]
[ERROR] no more than 100 items allowed [json-pointer:/view/blocks/0/elements/0/options]
```

**Root cause:** the update modal built a `static_select` populated with *every* incident (open + closed + invalid). Slack caps a select menu at **100 options**, so once the database grew past 100 incidents `views.open` was rejected and the update modal stopped opening entirely.

## Changes

- **`bolt.ts`** — switch the incident picker from `static_select` (all options inline in the view) to `external_select` whose options are provided lazily by a new `app.options('loaded_incidents')` handler. Slack calls it on open/typing; it queries incidents, filters server-side by the typed text, and returns at most 100 matches. This removes the hard limit and adds search over a growing incident list.
  - `min_query_length: 0` keeps the old UX — options load as soon as the menu opens, no typing required.
  - Ordering is unchanged (open by severity, then closed/invalid by date) via the extracted `buildLoadedIncidentsOptions` helper.
  - Selection handler cast updated to `ExternalSelectAction` with a guard on the now-optional `selected_option`.
- **`Dockerfile`** — pin the base image to `node:24.18.0-alpine` (was the floating `node:lts-alpine`) to match the Node 24 CI upgrade in #98.

## Behavioral note

The picker now shows the first 100 incidents by default and reveals the rest via search-as-you-type, rather than one giant scrollable list — the intended Slack pattern for large, growing datasets.

## Testing

- `yarn build` ✅
- `yarn lint:check` ✅
- `yarn test` ✅ (19/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)